### PR TITLE
fix: replace all registry references in component preview code

### DIFF
--- a/apps/www/components/component-preview.tsx
+++ b/apps/www/components/component-preview.tsx
@@ -17,7 +17,7 @@ export default async function ComponentPreview({
       `${name}.tsx`
     )
     let code = await fs.readFile(filePath, "utf-8")
-    code = code.replace("registry", "components")
+    code = code.replaceAll("@/registry", "@/components")
     const highlightedCode = await highlightCode(code)
 
     const mod = await import(`@/registry/examples/${name}.tsx`)


### PR DESCRIPTION
# Fix: Replace all registry references in component preview code #51 

## Problem
When displaying component examples, only the first occurrence of registry references was being replaced in the code. This caused issues with examples that have multiple imports from the registry.

## Solution
This PR makes the following changes:

1. Changed `replace()` to `replaceAll()` to ensure all occurrences are replaced
2. Updated the pattern from `"registry"` to `"@/registry"` for more precise matching
3. Updated the replacement from `"components"` to `"@/components"` to maintain the import path structure

## Changes

```diff
let code = await fs.readFile(filePath, "utf-8")
- code = code.replace("registry", "components")
+ code = code.replaceAll("@/registry", "@/components")
const highlightedCode = await highlightCode(code)
```