### PR TITLE
fix: code block overflow

### DIFF
--- a/apps/www/components/component-preview-tabs.tsx
+++ b/apps/www/components/component-preview-tabs.tsx
@@ -43,12 +43,12 @@ export default function ComponentPreviewTabs({
       </div>
       <div className="bg-secondary/25 relative grid aspect-video place-items-center gap-4">
         {activeTab === "preview" ? (
-          <div className="not-prose">{preview}</div>
+          <div className="not-prose max-w-full overflow-hidden">{preview}</div>
         ) : (
           <>
             <CopyButton value={code} />
             <div
-              className="size-full"
+              className="size-full overflow-auto"
               dangerouslySetInnerHTML={{ __html: highlightedCode }}
             />
           </>

--- a/apps/www/components/component-preview.tsx
+++ b/apps/www/components/component-preview.tsx
@@ -17,7 +17,7 @@ export default async function ComponentPreview({
       `${name}.tsx`
     )
     let code = await fs.readFile(filePath, "utf-8")
-    code = code.replace("registry", "components")
+    code = code.replaceAll("@/registry", "@/components")
     const highlightedCode = await highlightCode(code)
 
     const mod = await import(`@/registry/examples/${name}.tsx`)


### PR DESCRIPTION
# Fix code block overflow in component previews #49 

## Changes
- Added `overflow-hidden` and `max-w-full` to the preview container div to prevent horizontal overflow
- Added `overflow-auto` to the code preview div to enable scrolling for wide code blocks
- This provides a generalized solution that works for all component previews without requiring changes to individual components

## Testing
- Verified that the checkbox demo component with long class names no longer causes horizontal overflow
- Confirmed that the code preview still allows scrolling when code is wider than the container
- Tested other component previews to ensure the changes don't negatively impact their appearance

## Screenshots
Before: 
![image](https://github.com/user-attachments/assets/9233337f-0bdb-4d85-8a28-9f941d0dc40c)

After: 
![image](https://github.com/user-attachments/assets/5bb2db52-4ef8-4942-926e-d09a2cbf1756)
