### PR TITLE
ci: prebuild headcn package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,8 @@ jobs:
       - name: Install Deps
         run: pnpm install --frozen-lockfile
 
-      - name: Build .contentlayer
-        run: pnpm -F www build:contentlayer
+      - run: pnpm -F www build:contentlayer
+      - run: pnpm -F headcn build
 
       - run: pnpm lint
       - run: pnpm typecheck


### PR DESCRIPTION
An attempt to fix failing actions by building `headcn` workspace package before running rest of the tasks.
Changed workflow: `ci.yml`
