### PR TITLE
feat: json schema for components.json

### DIFF
--- a/apps/www/public/schema.json
+++ b/apps/www/public/schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "style": {
+      "type": "string",
+      "enum": ["default"]
+    },
+    "rsc": {
+      "type": "boolean"
+    },
+    "tsx": {
+      "type": "boolean"
+    },
+    "tailwind": {
+      "type": "object",
+      "properties": {
+        "css": {
+          "type": "string"
+        },
+        "prefix": {
+          "type": "string"
+        }
+      },
+      "required": ["css", "prefix"],
+      "additionalProperties": false
+    },
+    "iconLibrary": {
+      "type": "string",
+      "enum": ["@heroicons/react"]
+    },
+    "aliases": {
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "string"
+        },
+        "ui": {
+          "type": "string"
+        },
+        "utils": {
+          "type": "string"
+        }
+      },
+      "required": ["components", "utils"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["style", "rsc", "tsx", "tailwind", "aliases"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
Serve a `schema.json` from web server for auto-completions in `components.json` config file.
with "no additional properties".